### PR TITLE
Add cd and ls commands

### DIFF
--- a/src/main/java/com/galoev/Command.java
+++ b/src/main/java/com/galoev/Command.java
@@ -15,5 +15,5 @@ public interface Command {
    * @return result of command execution as InputStream
    * @throws Exception errors that commands can throw
    */
-  InputStream execute(List<String> args, InputStream input) throws Exception;
+  InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception;
 }

--- a/src/main/java/com/galoev/CommandCat.java
+++ b/src/main/java/com/galoev/CommandCat.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -12,14 +13,14 @@ import java.util.List;
  */
 public class CommandCat implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) throws Exception {
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
     if (args.isEmpty()) {
       return input;
     } else {
       var result = new StringBuilder();
       for (String arg : args) {
         try {
-          result.append(new String(Files.readAllBytes(Paths.get(arg))));
+          result.append(new String(Files.readAllBytes(Utils.addWorkingDir(environment, Paths.get(arg)))));
         } catch (NoSuchFileException e) {
           throw new Exception("File " + arg + " not found");
         }

--- a/src/main/java/com/galoev/CommandCd.java
+++ b/src/main/java/com/galoev/CommandCd.java
@@ -1,0 +1,29 @@
+package com.galoev;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Command that changes current working directory
+ */
+public class CommandCd implements Command {
+  @Override
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
+    //noinspection StatementWithEmptyBody
+    if (args.isEmpty()) {
+      // noop
+    } else if (args.size() == 1) {
+      if (!environment.setWorkingDir(Utils.addWorkingDir(environment, Path.of(args.get(0))))) {
+        throw new NoSuchFileException("cd: " + args.get(0) + " Not a directory");
+      }
+    } else {
+       throw new IllegalStateException("cd: wrong argument count. Usage 'cd [path]'");
+    }
+
+    return new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/com/galoev/CommandEcho.java
+++ b/src/main/java/com/galoev/CommandEcho.java
@@ -9,7 +9,7 @@ import java.util.List;
  */
 public class CommandEcho implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) throws Exception {
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
     return new ByteArrayInputStream((String.join(" ", args) + "\n").getBytes());
   }
 }

--- a/src/main/java/com/galoev/CommandExit.java
+++ b/src/main/java/com/galoev/CommandExit.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 public class CommandExit implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) throws Exception {
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
     System.exit(0);
     return null;
   }

--- a/src/main/java/com/galoev/CommandExternal.java
+++ b/src/main/java/com/galoev/CommandExternal.java
@@ -9,8 +9,10 @@ import java.util.List;
  */
 public class CommandExternal implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) throws Exception {
-    var processBuilder = new ProcessBuilder(args);
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
+    var processBuilder = new ProcessBuilder(args)
+        .directory(environment.getWorkingDir().toFile());
+
     processBuilder.redirectErrorStream(true);
     Process process;
     try {

--- a/src/main/java/com/galoev/CommandLs.java
+++ b/src/main/java/com/galoev/CommandLs.java
@@ -1,0 +1,49 @@
+package com.galoev;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Command that lists content of current working directory
+ */
+public class CommandLs implements Command {
+  @Override
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
+    String output;
+
+    if (args.isEmpty()) {
+      output = Arrays.stream(Objects.requireNonNull(
+          environment
+            .getWorkingDir()
+            .toFile()
+            .listFiles()
+        ))
+        .reduce("", (str, file) -> str + " " + file.getName(), (x, y) -> x + y)
+        .strip();
+    } else if (args.size() == 1) {
+      final var path = Utils.addWorkingDir(environment, Path.of(args.get(0)));
+
+      if (path.toFile().isDirectory()) {
+        output = Arrays.stream(
+            path
+              .toFile()
+              .listFiles()
+          )
+          .reduce("", (str, file) -> str + " " + file.getName(), (x, y) -> x + y)
+          .strip();
+      } else {
+        output = args.get(0);
+      }
+
+    } else {
+      throw new IllegalStateException("ls: wrong argument number. Usage 'ls [path]'");
+    }
+
+    return new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/com/galoev/CommandPwd.java
+++ b/src/main/java/com/galoev/CommandPwd.java
@@ -10,8 +10,8 @@ import java.util.List;
  */
 public class CommandPwd implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) {
-    var path = Paths.get(".").toAbsolutePath().normalize() + "\n";
+  public InputStream execute(Environment environment, List<String> args, InputStream input) {
+    var path = environment.getWorkingDir() + "\n";
     return new ByteArrayInputStream(path.getBytes());
   }
 }

--- a/src/main/java/com/galoev/CommandWc.java
+++ b/src/main/java/com/galoev/CommandWc.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -13,7 +14,7 @@ import org.apache.commons.io.IOUtils;
  */
 public class CommandWc implements Command {
   @Override
-  public InputStream execute(List<String> args, InputStream input) throws Exception {
+  public InputStream execute(Environment environment, List<String> args, InputStream input) throws Exception {
     var result = new StringBuilder();
     int curLinesCount = 0;
     int curWordsCount = 0;
@@ -32,7 +33,7 @@ public class CommandWc implements Command {
     } else {
       for (String arg : args) {
         try {
-          var text = new String(Files.readAllBytes(Paths.get(arg)));
+          var text = new String(Files.readAllBytes(Utils.addWorkingDir(environment, Path.of(arg))));
           curLinesCount = text.split("\n").length;
           curWordsCount = text.trim().split("\\s+").length;
           curBytesCount = text.length();

--- a/src/main/java/com/galoev/Environment.java
+++ b/src/main/java/com/galoev/Environment.java
@@ -1,5 +1,7 @@
 package com.galoev;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,6 +10,21 @@ import java.util.Map;
  */
 public class Environment {
   private Map<String, String> varValues = new HashMap<>();
+  private Path workingDir = Paths.get("").toAbsolutePath().normalize();
+
+  public Path getWorkingDir() {
+    return workingDir;
+  }
+
+  public boolean setWorkingDir(Path workingDir) {
+    if (workingDir.toFile().isDirectory()) {
+      this.workingDir = workingDir.toAbsolutePath().normalize();
+
+      return true;
+    }
+
+    return false;
+  }
 
   /**
    * Sets the environment variable by the passed variable and its value.

--- a/src/main/java/com/galoev/Parser.java
+++ b/src/main/java/com/galoev/Parser.java
@@ -18,7 +18,9 @@ public class Parser {
       "echo", new CommandEcho(),
       "wc", new CommandWc(),
       "pwd", new CommandPwd(),
-      "exit", new CommandExit()
+      "exit", new CommandExit(),
+      "ls", new CommandLs(),
+      "cd", new CommandCd()
   ));
 
   /**

--- a/src/main/java/com/galoev/Parser.java
+++ b/src/main/java/com/galoev/Parser.java
@@ -14,11 +14,11 @@ import org.apache.commons.io.IOUtils;
  */
 public class Parser {
   private static final Map<String, Command> COMMANDS = new HashMap<>(Map.of(
-          "cat", new CommandCat(),
-          "echo", new CommandEcho(),
-          "wc", new CommandWc(),
-          "pwd", new CommandPwd(),
-          "exit", new CommandExit()
+      "cat", new CommandCat(),
+      "echo", new CommandEcho(),
+      "wc", new CommandWc(),
+      "pwd", new CommandPwd(),
+      "exit", new CommandExit()
   ));
 
   /**
@@ -54,6 +54,7 @@ public class Parser {
         arguments = words;
       }
       inputStream = command.execute(
+              environment,
               arguments.stream().map(Token::getValue).collect(Collectors.toList()),
               inputStream);
     }

--- a/src/main/java/com/galoev/Utils.java
+++ b/src/main/java/com/galoev/Utils.java
@@ -1,0 +1,15 @@
+package com.galoev;
+
+import java.nio.file.Path;
+
+public class Utils {
+  private Utils() {}
+
+  public static Path addWorkingDir(Environment environment, Path path) {
+    if (!path.isAbsolute()) {
+      return Path.of(environment.getWorkingDir().toString(), path.toString()).normalize();
+    }
+
+    return path;
+  }
+}

--- a/src/main/java/com/galoev/Utils.java
+++ b/src/main/java/com/galoev/Utils.java
@@ -5,6 +5,12 @@ import java.nio.file.Path;
 public class Utils {
   private Utils() {}
 
+  /**
+   * Adds current working directory to relative path
+   * @param environment current environment
+   * @param path path to be changed
+   * @return If given path is relative returns new absolute path to the same place, else returns the same path
+   */
   public static Path addWorkingDir(Environment environment, Path path) {
     if (!path.isAbsolute()) {
       return Path.of(environment.getWorkingDir().toString(), path.toString()).normalize();

--- a/src/test/java/com/galoev/CommandTest.java
+++ b/src/test/java/com/galoev/CommandTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
  * In this class, test cases for commands.
  */
 public class CommandTest {
+  private final Environment environment = new Environment();
 
   @Test
   public void testCat1() throws Exception {
@@ -27,6 +28,7 @@ public class CommandTest {
     byte[] buf = text.getBytes();
     Files.write(path, buf);
     InputStream inputStream = command.execute(
+            environment,
             Collections.singletonList(path.toAbsolutePath().toString()),
             new ByteArrayInputStream("".getBytes())
     );
@@ -39,6 +41,7 @@ public class CommandTest {
     Command command = new CommandCat();
     String text = "Hello World!";
     InputStream inputStream = command.execute(
+            environment,
             new ArrayList<>(),
             new ByteArrayInputStream(text.getBytes())
     );
@@ -79,6 +82,7 @@ public class CommandTest {
 
     Command command = new CommandCat();
     InputStream inputStream = command.execute(
+            environment,
             args,
             new ByteArrayInputStream("".getBytes())
     );
@@ -90,6 +94,7 @@ public class CommandTest {
   public void testCat4() throws Exception {
     Command command = new CommandCat();
     command.execute(
+            environment,
             Collections.singletonList("NoSuchFile.txt"),
             new ByteArrayInputStream("".getBytes())
     );
@@ -99,6 +104,7 @@ public class CommandTest {
   public void testEcho1() throws Exception {
     Command command = new CommandEcho();
     InputStream inputStream = command.execute(
+            environment,
             new ArrayList<>(),
             new ByteArrayInputStream("".getBytes())
     );
@@ -113,6 +119,7 @@ public class CommandTest {
     args.add("World");
     args.add("!");
     InputStream inputStream = command.execute(
+            environment,
             args,
             new ByteArrayInputStream("".getBytes())
     );
@@ -127,6 +134,7 @@ public class CommandTest {
     byte[] buf = text.getBytes();
     Files.write(path, buf);
     InputStream inputStream = command.execute(
+            environment,
             Collections.singletonList(path.toAbsolutePath().toString()),
             new ByteArrayInputStream("".getBytes())
     );
@@ -169,6 +177,7 @@ public class CommandTest {
 
     Command command = new CommandWc();
     InputStream inputStream = command.execute(
+            environment,
             args,
             new ByteArrayInputStream("".getBytes())
     );
@@ -180,6 +189,7 @@ public class CommandTest {
   public void testWc3() throws Exception {
     Command command = new CommandWc();
     command.execute(
+            environment,
             Collections.singletonList("NoSuchFile.txt"),
             new ByteArrayInputStream("".getBytes())
     );
@@ -190,6 +200,7 @@ public class CommandTest {
     Command command = new CommandExternal();
     String text = "Hello World!" + System.lineSeparator() + "Hello World!";
     InputStream inputStream = command.execute(
+            environment,
             Arrays.asList("echo", text),
             new ByteArrayInputStream("".getBytes())
     );
@@ -200,6 +211,7 @@ public class CommandTest {
   public void testPwd() throws Exception {
     Command command = new CommandPwd();
     InputStream inputStream = command.execute(
+            environment,
             new ArrayList<>(),
             new ByteArrayInputStream("".getBytes())
     );

--- a/src/test/java/com/galoev/EnvironmentTest.java
+++ b/src/test/java/com/galoev/EnvironmentTest.java
@@ -1,8 +1,13 @@
 package com.galoev;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * In this class, test cases for the class Environment.
@@ -12,10 +17,11 @@ public class EnvironmentTest {
   public void testEmptyEnvironment() {
     Environment environment = new Environment();
     assertEquals("", environment.getVal("var"));
+    assertEquals(Paths.get("").toAbsolutePath().normalize(), environment.getWorkingDir());
   }
 
   @Test
-  public void testPerformance() {
+  public void testPerformance() throws IOException {
     Environment environment = new Environment();
     environment.putVal("var1", "val1");
     assertEquals("", environment.getVal("var"));
@@ -23,5 +29,16 @@ public class EnvironmentTest {
     environment.putVal("var2", "val2");
     assertEquals("val1", environment.getVal("var1"));
     assertEquals("val2", environment.getVal("var2"));
+
+    assertTrue(environment.setWorkingDir(Paths.get("../")));
+    assertEquals(Paths.get("../").toAbsolutePath().normalize(), environment.getWorkingDir());
+    var prevDir = environment.getWorkingDir().toString();
+    var f = Files.createTempFile("test", "tmp");
+    assertFalse(environment.setWorkingDir(f));
+    assertEquals(
+        "Setting working directory to a file doesnt change anything",
+        prevDir,
+        environment.getWorkingDir().toString()
+    );
   }
 }


### PR DESCRIPTION
Оставлю ревью по архитектуре здесь. Проблем с добавлением новой функциональности не возникло. Т.к. код простой, как доска и разобраться что в нём к чему довольно легко. С другой стороны есть некоторые проблемы.
- Лексер и парсер императивные. С увеличеним сложности грамматики это может стать проблемой. Кроме того, исполнение команд, по какой-то причине, часть парсера.
- Команды принимают и отдают `InputStream`. Во-первых, с точки зрения чтения интерфейса не очень понятно, почему команда отдаёт поток для ввода, но, возможно, это обусловленно техническими проблемами конвертации выходного потока во входной в пайплайнах. Я не очень хорошо знаю эту часть Java API. Во-вторых, с первого взгляда кажется, что это решает ту же проблему, что есть в моей реализации -- потенциально бесконечный ввод/вывод, но, фактически, внутри команды, этот поток целиком преобразуется в строку, так что проблема остаётся
- Мутабельный `Environment` общий на всеь мир (но, хотя бы, не синглтон, как у меня :-) ). В идеале хочется добавить к нему прокси обёртки, чтобы передавать в команды внутри пайплайна (в bash команды внутри пайплайна не мутируют общий environment)
- Код лежит в одном пакете. Да, его немного, но всё равно хочется разделить. Кроме того, все тесты для команд так же находятся в одном файле. При росте количества и сложности команд этот файл рискует раздуться до нечитаемых размеров